### PR TITLE
explorer page persists URL and tab selection

### DIFF
--- a/src/Compute.elm
+++ b/src/Compute.elm
@@ -1,4 +1,4 @@
-module Compute exposing (Model, Msg, Settings, Tab(..), defaults, init, subscriptions, update, view)
+module Compute exposing (Model, Msg(..), Settings, Tab(..), defaults, init, subscriptions, update, view)
 
 import Chart as C
 import Chart.Attributes as CA

--- a/src/Compute.elm
+++ b/src/Compute.elm
@@ -1,4 +1,4 @@
-module Compute exposing (Model, Msg, Settings, defaults, init, subscriptions, update, view)
+module Compute exposing (Model, Msg, Settings, Tab(..), defaults, init, subscriptions, update, view)
 
 import Chart as C
 import Chart.Attributes as CA

--- a/src/Pages/Explorer.elm
+++ b/src/Pages/Explorer.elm
@@ -68,10 +68,10 @@ update req msg model =
                 Explorer subMsg ->
                     case subMsg of
                         OnTabSelected tab ->
-                            Navigation.pushUrl req.key (encodeNewUrl model.query tab)
+                            Navigation.replaceUrl req.key (encodeNewUrl model.query tab)
 
                         OnDebounce ->
-                            Navigation.pushUrl req.key (encodeNewUrl model.query model.selectedTab)
+                            Navigation.replaceUrl req.key (encodeNewUrl model.query model.selectedTab)
 
                         _ ->
                             Cmd.none

--- a/src/Pages/Explorer.elm
+++ b/src/Pages/Explorer.elm
@@ -12,13 +12,14 @@ import Url.Parser exposing (..)
 import View exposing (View)
 
 
+
 type alias Model =
-    { wordCloud : Compute.Model
+    { explorer : Compute.Model
     }
 
 
 type Msg
-    = WordCloudMsg Compute.Msg
+    = Explorer Compute.Msg
 
 
 page : Shared.Model -> Request -> Page.With Model Msg
@@ -37,18 +38,18 @@ init shared =
         ( subModel, subCmd ) =
             Compute.init shared
     in
-    ( { wordCloud = subModel }, Cmd.map WordCloudMsg subCmd )
+    ( { explorer = subModel }, Cmd.map Explorer subCmd )
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        WordCloudMsg subMsg ->
+        Explorer subMsg ->
             let
                 ( subModel, subCmd ) =
-                    Compute.update subMsg model.wordCloud
+                    Compute.update subMsg model.explorer
             in
-            ( { model | wordCloud = subModel }, Cmd.map WordCloudMsg subCmd )
+            ( { model | explorer = subModel }, Cmd.map Explorer subCmd )
 
 
 view : Model -> View Msg
@@ -58,7 +59,7 @@ view model =
         Layout.body
             [ E.column [ E.centerX, E.paddingXY 0 64 ]
                 [ E.el [ Region.heading 1, Font.size 24 ] (E.text "Compute data explorer")
-                , E.el [ E.paddingXY 0 32, E.width E.fill ] (E.map WordCloudMsg (Compute.view Compute.defaults model.wordCloud))
+                , E.el [ E.paddingXY 0 32, E.width E.fill ] (E.map Explorer (Compute.view Compute.defaults model.explorer))
                 , E.el [ Region.heading 2, Font.size 20, E.paddingEach { top = 64, right = 0, bottom = 0, left = 0 } ] (E.text "How do I use this?")
                 , E.paragraph [ E.paddingEach { top = 32, right = 0, bottom = 0, left = 0 }, E.width (E.fill |> E.maximum 800) ]
                     [ E.text "Documentation is lacking right now, sorry! We're working on it. For now I suggest you check out "
@@ -72,4 +73,4 @@ view model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.map WordCloudMsg (Compute.subscriptions model.wordCloud)
+    Sub.map Explorer (Compute.subscriptions model.explorer)

--- a/src/Pages/Explorer.elm
+++ b/src/Pages/Explorer.elm
@@ -14,8 +14,7 @@ import View exposing (View)
 
 
 type alias Model =
-    { explorer : Compute.Model
-    }
+    Compute.Model
 
 
 type Msg
@@ -66,29 +65,23 @@ page shared { query } =
 
 init : Shared.Model -> UrlParams -> ( Model, Cmd Msg )
 init shared urlParams =
-    let
-        ( subModel, subCmd ) =
-            Compute.init shared
-                |> Tuple.mapFirst
-                    (\model ->
-                        { model
-                            | query = Maybe.withDefault model.query urlParams.query
-                            , selectedTab = Maybe.withDefault model.selectedTab urlParams.tab
-                        }
-                    )
-    in
-    ( { explorer = subModel }, Cmd.map Explorer subCmd )
+    Compute.init shared
+        |> Tuple.mapBoth
+            (\model ->
+                { model
+                    | query = Maybe.withDefault model.query urlParams.query
+                    , selectedTab = Maybe.withDefault model.selectedTab urlParams.tab
+                }
+            )
+            (Cmd.map Explorer)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         Explorer subMsg ->
-            let
-                ( subModel, subCmd ) =
-                    Compute.update subMsg model.explorer
-            in
-            ( { model | explorer = subModel }, Cmd.map Explorer subCmd )
+            Compute.update subMsg model
+                |> Tuple.mapSecond (Cmd.map Explorer)
 
 
 view : Model -> View Msg
@@ -98,7 +91,7 @@ view model =
         Layout.body
             [ E.column [ E.centerX, E.paddingXY 0 64 ]
                 [ E.el [ Region.heading 1, Font.size 24 ] (E.text "Compute data explorer")
-                , E.el [ E.paddingXY 0 32, E.width E.fill ] (E.map Explorer (Compute.view Compute.defaults model.explorer))
+                , E.el [ E.paddingXY 0 32, E.width E.fill ] (E.map Explorer (Compute.view Compute.defaults model))
                 , E.el [ Region.heading 2, Font.size 20, E.paddingEach { top = 64, right = 0, bottom = 0, left = 0 } ] (E.text "How do I use this?")
                 , E.paragraph [ E.paddingEach { top = 32, right = 0, bottom = 0, left = 0 }, E.width (E.fill |> E.maximum 800) ]
                     [ E.text "Documentation is lacking right now, sorry! We're working on it. For now I suggest you check out "
@@ -112,4 +105,4 @@ view model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.map Explorer (Compute.subscriptions model.explorer)
+    Sub.map Explorer (Compute.subscriptions model)


### PR DESCRIPTION
As in title. Doesn't persist the other toggle selections or whatever, this is just a quick addition. You can go by commit if you want to see some process but since this is experimental feel free to stamp.

Also I renamed `wordCloud` -> `Explorer` for now, we can bring back a word cloud page if that makes sense