### PR TITLE
tidy code for zulip/dev page, to generalize with later

### DIFF
--- a/src/Compute.elm
+++ b/src/Compute.elm
@@ -488,7 +488,7 @@ linkCloudView query data =
         ( _, queryUrl ) =
             parseLinkQuery query
     in
-    E.paragraph [ F.size 18, E.spacing 8 ]
+    E.wrappedRow [ F.size 18, E.spacing 4 ]
         (List.map
             (\value ->
                 let

--- a/src/Pages/S/Zulip/Dev.elm
+++ b/src/Pages/S/Zulip/Dev.elm
@@ -1,26 +1,74 @@
 module Pages.S.Zulip.Dev exposing (Model, Msg, init, page, update, view)
 
-import Compute
-import ComputeBackend
+import Compute exposing (Tab(..))
+import Dict exposing (Dict)
 import Element as E
 import Element.Font as Font
 import Element.Region as Region
 import Layout
 import Page
-import Panels
 import Request exposing (Request)
 import Shared
+import Task
 import Url.Parser exposing (..)
 import View exposing (View)
 
 
-type alias Model =
-    { panels : Panels.Model
+data =
+    [ { description = "Top committers to github.com/zulip/zulip in last 6mo"
+      , query = "repo:github\\.com/zulip/zulip$ content:output((.|\n)* -> $author) type:commit since:\"6 months ago\" count:all"
+      , dataPoints = 10
+      , sortByCount = True
+      , reverse = False
+      , excludeStopWords = False
+      , selectedTab = Chart
+      , editible = False
+      }
+    , { description = "Commit message topics in last 3mo"
+      , query = "repo:github\\.com/zulip/zulip$ type:commit since:\"3 months ago\" count:10000 content:output((?i)(zulip|add|update|fixes|remove)|(\\w+) -> $2) @@@ https://sourcegraph.com/search?q=context:global+r\nepo:github%5C.com/golang/go%24+type:commit+$1&patternType=regexp"
+      , dataPoints = 50
+      , sortByCount = True
+      , reverse = False
+      , excludeStopWords = True
+      , selectedTab = LinkCloud
+      , editible = False
+      }
+    , { description = "Most modified files in last 2mo"
+      , query = "since:\"2 months ago\" repo:github\\.com/zulip/zulip$ content:output(^.*/.*\\ (.*/.*) -> $1) type:diff count:all @@@ https://sourcegraph.com/search?q=context:global+repo:github%5C.com/zulip/zulip%24+type:diff+file:$1&patternType=literal"
+      , dataPoints = 10
+      , sortByCount = True
+      , reverse = False
+      , excludeStopWords = True
+      , selectedTab = Table
+      , editible = False
+      }
+    ]
+
+
+type alias Panel =
+    { description : String
+    , inputs : Compute.Model
     }
 
 
+type alias Model =
+    Dict Int Panel
+
+
 type Msg
-    = PanelsMsg Panels.Msg
+    = Update Int Compute.Msg
+
+
+type alias PanelInputs =
+    { description : String
+    , query : String
+    , selectedTab : Tab
+    , dataPoints : Int
+    , sortByCount : Bool
+    , reverse : Bool
+    , excludeStopWords : Bool
+    , editible : Bool
+    }
 
 
 page : Shared.Model -> Request -> Page.With Model Msg
@@ -34,65 +82,57 @@ page shared _ =
 
 
 init : Shared.Model -> ( Model, Cmd Msg )
-init shared =
+init _ =
     let
-        panel0 : ComputeBackend.ComputeInput
-        panel0 =
-            { computeQueries = [ "repo:github\\.com/zulip/zulip$ content:output((.|\n)* -> $author) type:commit since:\"6 months ago\" count:all" ]
-            , experimentalOptions =
-                Just
-                    { dataPoints = Just 10
-                    , sortByCount = Just True
-                    , reverse = Nothing
-                    , excludeStopWords = Nothing
-                    }
-            , editible = Just False
-            , selectedTab = Just "chart"
-            }
-
-        panel1 : ComputeBackend.ComputeInput
-        panel1 =
-            { computeQueries = [ "repo:github\\.com/zulip/zulip$ type:commit since:\"3 months ago\" count:10000 content:output((?i)(zulip|add|update|fixes|remove)|(\\w+) -> $2) @@@ https://sourcegraph.com/search?q=context:global+repo:github%5C.com/golang/go%24+type:commit+$1&patternType=regexp" ]
-            , experimentalOptions =
-                Just
-                    { dataPoints = Just 50
-                    , sortByCount = Just True
-                    , reverse = Nothing
-                    , excludeStopWords = Just True
-                    }
-            , editible = Just False
-            , selectedTab = Just "link-cloud"
-            }
-
-        panel2 : ComputeBackend.ComputeInput
-        panel2 =
-            { computeQueries = [ "since:\"2 months ago\" repo:github\\.com/zulip/zulip$ content:output(^.*/.*\\ (.*/.*) -> $1) type:diff count:all @@@ https://sourcegraph.com/search?q=context:global+repo:github%5C.com/zulip/zulip%24+type:diff+file:$1&patternType=literal" ]
-            , experimentalOptions =
-                Just
-                    { dataPoints = Just 10
-                    , sortByCount = Just True
-                    , reverse = Nothing
-                    , excludeStopWords = Just True
-                    }
-            , editible = Just False
-            , selectedTab = Just "table"
-            }
-
-        ( panelsModel, panelsCmd ) =
-            Panels.init PanelsMsg shared [ panel0, panel1, panel2 ]
+        model =
+            data
+                |> List.map initPanel
+                |> List.indexedMap Tuple.pair
+                |> Dict.fromList
     in
-    ( { panels = panelsModel }, panelsCmd )
+    ( model
+    , Dict.keys model
+        |> List.map (\i -> Task.perform identity (Task.succeed (Update i Compute.RunCompute)))
+        |> Cmd.batch
+    )
+
+
+initPanel : PanelInputs -> Panel
+initPanel { description, query, selectedTab, dataPoints, sortByCount, reverse, excludeStopWords, editible } =
+    { description = description
+    , inputs =
+        { sourcegraphURL = "https://sourcegraph.com"
+        , query = query
+        , dataFilter =
+            { dataPoints = dataPoints
+            , sortByCount = sortByCount
+            , reverse = reverse
+            , excludeStopWords = excludeStopWords
+            }
+        , selectedTab = selectedTab
+        , editible = editible
+        , debounce = 0
+        , resultCount = 0
+        , resultsMap = Dict.empty
+        , serverless = False
+        }
+    }
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
-update msg model =
-    case msg of
-        PanelsMsg subMsg ->
-            let
-                ( subModel, subCmd ) =
-                    Panels.update PanelsMsg subMsg model.panels
-            in
-            ( { model | panels = subModel }, subCmd )
+update (Update i m) model =
+    (Dict.get i model
+        |> Maybe.map (Compute.update m << .inputs)
+        |> Maybe.map
+            (\( newInputs, cmd ) ->
+                ( Dict.update i
+                    (Maybe.map (\v -> { v | inputs = newInputs }))
+                    model
+                , Cmd.map (Update i) cmd
+                )
+            )
+    )
+        |> Maybe.withDefault ( model, Cmd.none )
 
 
 view : Model -> View Msg
@@ -101,21 +141,39 @@ view model =
     , body =
         Layout.body
             [ E.column [ E.centerX ]
-                [ E.el [ Region.heading 1, Font.size 24, E.paddingEach { top = 64, right = 0, bottom = 32, left = 0 } ]
-                    (E.text "Zulip development stats")
-                , E.el [ Region.heading 2, Font.size 20 ] (E.text "Top committers to github.com/zulip/zulip in last 6mo")
-                , E.el [ E.paddingEach { top = 0, right = 0, bottom = 32, left = 0 }, E.width E.fill ] (Panels.render PanelsMsg model.panels 0 Compute.defaults)
-                , E.el [ Region.heading 2, Font.size 20 ] (E.text "Commit message topics in last 3mo")
-                , E.el [ E.paddingEach { top = 0, right = 0, bottom = 32, left = 0 }, E.width E.fill ] (Panels.render PanelsMsg model.panels 1 { minHeight = Just 200 })
-                , E.el [ Region.heading 2, Font.size 20 ] (E.text "Most modified files in last 2mo")
-                , E.el [ E.paddingEach { top = 0, right = 0, bottom = 32, left = 0 }, E.width E.fill ] (Panels.render PanelsMsg model.panels 2 Compute.defaults)
-                , E.el [ Region.heading 2, Font.size 20 ] (E.text "How does this work?")
-                , Layout.howDoesThisWork
-                ]
+                ([ headerView ] ++ dataView model ++ [ footerView ])
             ]
     }
 
 
+headerView : E.Element Msg
+headerView =
+    E.el [ Region.heading 1, Font.size 24, E.paddingEach { top = 64, right = 0, bottom = 32, left = 0 } ]
+        (E.text "Zulip development stats")
+
+
+dataView : Model -> List (E.Element Msg)
+dataView model =
+    Dict.toList model
+        |> List.map
+            (\( i, { description, inputs } ) ->
+                E.column [ E.width E.fill, E.paddingEach { top = 0, right = 0, bottom = 32, left = 0 } ]
+                    [ E.el [ Region.heading 2, Font.size 20 ] (E.text description)
+                    , E.map (Update i) (Compute.view Compute.defaults inputs)
+                    ]
+            )
+
+
+footerView : E.Element Msg
+footerView =
+    E.column []
+        [ E.el [ Region.heading 2, Font.size 20 ] (E.text "How does this work?")
+        , Layout.howDoesThisWork
+        ]
+
+
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Panels.subscriptions PanelsMsg model.panels
+    Dict.toList model
+        |> List.map (\( i, { inputs } ) -> Sub.map (Update i) (Compute.subscriptions inputs))
+        |> Sub.batch


### PR DESCRIPTION
Towards removing the need for `Panels` and indirection. Want to remove or minimize `Cmd`/`Msg`/`Sub` mapping. Doing this for one page right now (this is the new template, basically), will do for the rest later.

Will self-approve and merge, just posting PR for visibility. I might just push other commits directly.